### PR TITLE
Update README.md to show the correct URL to the demo app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Implementation of a [TileSource](https://openseadragon.github.io/docs/OpenSeadra
 
 
 
-See it in action at [https://pearcetm.github.io/GeoTIFFTileSource/demo.html](https://pearcetm.github.io/GeoTIFFTileSource/demo.html)
+See it in action at [https://pearcetm.github.io/GeoTIFFTileSource/demo/demo.html](https://pearcetm.github.io/GeoTIFFTileSource/demo/demo.html)
 
 ## How to create GeoTIFF files
 


### PR DESCRIPTION
The link to the demo app is broken since the page was moved to be inside the /demo directory. This updates the link to reflect the correct URL.