### PR TITLE
Address #17 by filtering Macro and Label images from SVS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geotiff-tilesource",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A plugin tilesource for OpenSeadragon that uses geotiff.js to provide serverless access to view compatible local or remote TIFF files",
   "files": [
     "dist"

--- a/src/main.js
+++ b/src/main.js
@@ -131,6 +131,18 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
               globals.photometricInterpretations.TransparencyMask
           );
 
+          // Filter out macro thumbnails and labels
+          //   This is a modification according to the Aperio SVS format
+          //   https://web.archive.org/web/20120420105738/http://www.aperio.com/documents/api/Aperio_Digital_Slides_and_Third-party_data_interchange.pdf (pg 14)
+          //   which specifies to always strip macro and label thumbnails.
+          if (toLowerCase(fileExtension) == "svs"){
+            let labelFilter = (i) => {
+              var s = i.fileDirectory.ImageDescription.split("\n")[1];
+              return !(s.includes("macro") || s.includes("label"));
+            }
+            images = images.filter(labelFilter);
+          }
+
           // Sort by width (largest first), then detect pyramids
           images.sort((a, b) => b.getWidth() - a.getWidth());
 

--- a/src/main.js
+++ b/src/main.js
@@ -142,7 +142,14 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
           //   https://web.archive.org/web/20120420105738/http://www.aperio.com/documents/api/Aperio_Digital_Slides_and_Third-party_data_interchange.pdf (pg 14)
           const aspectRatioSets = images.reduce((accumulator, image) => {
             const r = image.getWidth() / image.getHeight();
-            const s = image.fileDirectory.ImageDescription.split("\n")[1];
+            let s = ""; // Initialize with no description
+
+            // Check whether the ImageDescription exists as a field just in case
+            if (image.fileDirectory.ImageDescription){
+              // Split out part of the description that signifies its type for identification
+              s = image.fileDirectory.ImageDescription.split("\n")[1];
+            }
+            
             const exists = accumulator.filter(
               (set) => ((Math.abs(1 - set.aspectRatio / r) < tolerance)
                 && !(s.includes("macro") || s.includes("label"))) // Separate out macro thumbnails and labels


### PR DESCRIPTION
This should fix #17 by filtering out macro & label images from SVS slides.  Currently looking for publicly available test data to validate this change.