### PR TITLE
feat: Allow direct `geotiff.js` options

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
    *                 opts.logLatency: print latency to fetch and process each tile to console.log or the provided function
    *                 opts.tileWidth: tileWidth to request at each level. Defaults to tileWidth specified by TIFF file or 256 if unspecified by the file
    *                 opts.tileHeight:tileWidth to request at each level. Defaults to tileWidth specified by TIFF file or 256 if unspecified by the file
+   * @param {Object} GeoTIFFOpts Options object to pass to [geotiff.js]{@link https://github.com/geotiffjs/geotiff.js}
    *
    * @property {Object} GeoTIFF The GeoTIFF.js representation of the underlying file. Undefined until the file is opened successfully
    * @property {Array}  GeoTIFFImages Array of GeoTIFFImage objects, each representing one layer. Undefined until the file is opened successfully
@@ -46,7 +47,7 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
     static sharedPool = new Pool();
     static _osdReady = false;
 
-    constructor(input, opts = { logLatency: false }) {
+    constructor(input, opts = { logLatency: false }, GeoTIFFOpts = {}) {
       super();
 
       if (!GeoTIFFTileSource._osdReady) {
@@ -76,7 +77,7 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
         this.setupLevels();
       } else {
         this.promises = {
-          GeoTIFF: input instanceof File ? fromBlob(input) : fromUrl(input),
+          GeoTIFF: input instanceof File ? fromBlob(input, GeoTIFFOpts) : fromUrl(input, GeoTIFFOpts),
           GeoTIFFImages: new DeferredPromise(),
           ready: new DeferredPromise(),
         };
@@ -109,11 +110,11 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
       GeoTIFFTileSource._osdReady = true;
     };
 
-    static getAllTileSources = async (input, opts) => {
+    static getAllTileSources = async (input, opts, GeoTIFFOpts = {}) => {
       const fileExtension =
         input instanceof File ? input.name.split(".").pop() : input.split(".").pop();
 
-      let tiff = input instanceof File ? fromBlob(input) : fromUrl(input);
+      let tiff = input instanceof File ? fromBlob(input, GeoTIFFOpts) : fromUrl(input, GeoTIFFOpts);
 
       return tiff
         .then((t) => {


### PR DESCRIPTION
I just add a third parameter to pass `geotiff.js` options.

My particular use case is the `allowFullFile` option to load some local files and avoid the `AggregateError: Request failed error`.

Thanks for this fantastic library.