### PR TITLE
feat: TIFF directory images filter

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
    * @param {File|String|Object} input A File object, url string, or object with fields for pre-loaded GeoTIFF and GeoTIFFImages objects
    * @param {Object} opts Options object. To do: how to document options fields?
    *                 opts.logLatency: print latency to fetch and process each tile to console.log or the provided function
+   *                 opts.imagesFilter: array of indices to filter images by, or an array filter function to apply to the images array
    *                 opts.tileWidth: tileWidth to request at each level. Defaults to tileWidth specified by TIFF file or 256 if unspecified by the file
    *                 opts.tileHeight:tileWidth to request at each level. Defaults to tileWidth specified by TIFF file or 256 if unspecified by the file
    *
@@ -90,6 +91,8 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
             return Promise.all(promises);
           })
           .then((images) => {
+            images = self.constructor.userDefinedImagesFilter(images, opts);
+
             self.GeoTIFFImages = images;
             self.promises.GeoTIFFImages.resolve(images);
             this.setupLevels();
@@ -124,6 +127,8 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
           Promise.all([...Array(c).keys()].map(async (index) => (await tiff).getImage(index)))
         )
         .then((images) => {
+          images = this.userDefinedImagesFilter(images, opts);
+
           // Filter out images with photometricInterpretation.TransparencyMask
           images = images.filter(
             (image) =>
@@ -520,6 +525,19 @@ export const enableGeoTIFFTileSource = (OpenSeadragon) => {
           return dataURL;
         });
       }
+    };
+
+    static userDefinedImagesFilter = (images, opts) => {
+      if (typeof opts.imagesFilter !== 'undefined' && opts.imagesFilter) {
+        if (Array.isArray(opts.imagesFilter))
+          images = images.filter((_, idx) => opts.imagesFilter.includes(idx));
+        else if (typeof opts.imagesFilter === "function")
+          images = images.filter(opts.imagesFilter);
+
+        opts.imagesFilter = undefined;
+      }
+
+      return images;
     };
   }
 


### PR DESCRIPTION
I added an option to filter the images (directory) of the TIFF image, I have to use this because I am reading an Aperio SVS slide file which is a TIFF file,  have the pyramid images and 2 additional images at the end for a label and a macro picture so I have to filter the last two.

```javascript
// Can be filtered by function
 openSeadragonViewerConfig.tileSources = await OpenSeadragon
    .GeoTIFFTileSource
    .getAllTileSources( 'slide.svs', { imagesFilter: (_, i, a) => i  < (a.length - 2) })
        
// Or an array with the directory index to use
openSeadragonViewerConfig.tileSources = await OpenSeadragon
    .GeoTIFFTileSource
    .getAllTileSources( 'slide.svs', { imagesFilter:  [ 1, 2 ]})
```

Thanks for the library.