### PR TITLE
Fix peer dependencies for OpenSeadragon v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "geotiff": "^2.1.2"
   },
   "peerDependencies": {
-    "openseadragon": "^3.0.0 || ^4.0.0 || ^5.0.0" || ^6.0.0"
+    "openseadragon": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request makes minor updates to the `package.json` file, including a patch version bump and expanding peer dependency support.

- Version update:
  * Bumped the package version from `2.3.0` to `2.3.1` to reflect the new changes.

- Dependency compatibility:
  * Expanded the supported versions of `openseadragon` in `peerDependencies` to include `^6.0.0`.